### PR TITLE
Use php-coveralls/php-coveralls instead of satooshi/php-coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "dev",
     "require-dev": {
         "phpunit/phpunit": "5.7.*",
-        "satooshi/php-coveralls": "dev-master"       
+        "php-coveralls/php-coveralls": "2.1.x-dev"       
     },
     "require": {
         "php": ">=5.6.0",


### PR DESCRIPTION
When installing dependencies, I was unable to install `satooshi/php-coveralls` :

```
λ  soundcloud master ✗ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package satooshi/php-coveralls dev-master exists as satooshi/php-coveralls[0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.3.2, 0.4.0, 0.5.0, 1.0.x-dev, 1.1.x-dev, 2.0.x-dev, v0.6.0, v0.6.1, v0.7.0, v0.7.1, v1.0.0, v1.0.1, v1.0.2, v1.1.0, v2.0.0] but these are rejected by your constraint.
```

Furthermore, the library seems to be abandoned and replaced by `php-coveralls/php-coveralls`.