### PR TITLE
Remove syntaxCheck attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
         "satooshi/php-coveralls": "dev-master"       
+        "phpunit/phpunit": ">=7.0.0",
     },
     "require": {
         "php": ">=5.6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false"
-    syntaxCheck="false">
+    stopOnFailure="false">
     
     <testsuites>
         <testsuite name="Soundcloud API Tests">


### PR DESCRIPTION
When running unit tests, a warning is displayed :

```
λ  soundcloud master ✗ phpunit --bootstrap vendor/autoload.php                
PHPUnit 7.2.4 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 11:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.

[...]
```

Solution is to completely remove this attribute.